### PR TITLE
Add 'desktop_browser' to the list of keys to ignore

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,7 +150,8 @@ module.exports.init = function() {
           'app_description',
           'developer_name',
           'app_name',
-          'existing_manifest'];
+          'existing_manifest',
+          'desktop_browser'];
         var newContent = (keysToIgnore.indexOf(uKey) >= 0)
           ? request[key]
           : exports.camelCaseToUnderscoreRequest(request[key]);

--- a/index.js
+++ b/index.js
@@ -151,7 +151,8 @@ module.exports.init = function() {
           'developer_name',
           'app_name',
           'existing_manifest',
-          'desktop_browser'];
+          'desktop_browser'
+        ];
         var newContent = (keysToIgnore.indexOf(uKey) >= 0)
           ? request[key]
           : exports.camelCaseToUnderscoreRequest(request[key]);


### PR DESCRIPTION
'backgroundRadius' doesn't work when converting camelCase to underscore, so adding it's parent key of 'desktop_browser' to the ignore list to prevent the conversion.

the other camelCased keys here ('backgroundColor' and 'imageScale') seem to work either way, so no harm there.

Fixes RealFaviconGenerator/realfavicongenerator#449
Fixes RealFaviconGenerator/realfavicongenerator#458