### PR TITLE
Add underscores for Windows tile config

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,8 @@ module.exports.init = function() {
           'app_name',
           'existing_manifest',
           'background_color',
-          'theme_color'];
+          'theme_color'
+        ];
         var newContent = (keysToIgnore.indexOf(uKey) >= 0)
           ? request[key]
           : exports.camelCaseToUnderscoreRequest(request[key]);

--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ module.exports.init = function() {
     //  by one or more additional digits, so it will insert an underscore before the "8" and the "1" in
     //  "windows80Ie10Tile" (yielding "windows_80_ie_10_tile", but NOT before the "6" in "ios6AndPriorIcons" (yielding
     //  "ios6_and_prior_icons").
-    return s.replace(/(?:^|\.?)([A-Z]|(?<=[a-z])\d(?=\d+[A-Z]))/g, function(x,y) {
+    return s.replace(/(?:^|\.?)([A-Z]|(?<=[a-z])\d(?=\d+))/g, function(x,y) {
       return "_" + y.toLowerCase()
     }).replace(/^_/, "");
   }
@@ -154,7 +154,9 @@ module.exports.init = function() {
           'app_description',
           'developer_name',
           'app_name',
-          'existing_manifest'];
+          'existing_manifest',
+          'background_color',
+          'theme_color'];
         var newContent = (keysToIgnore.indexOf(uKey) >= 0)
           ? request[key]
           : exports.camelCaseToUnderscoreRequest(request[key]);

--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ module.exports.init = function() {
     //  by one or more additional digits, so it will insert an underscore before the "8" and the "1" in
     //  "windows80Ie10Tile" (yielding "windows_80_ie_10_tile", but NOT before the "6" in "ios6AndPriorIcons" (yielding
     //  "ios6_and_prior_icons").
-    return s.replace(/(?:^|\.?)([A-Z]|(?<=[a-z])\d(?=\d+))/g, function(x,y) {
+    return s.replace(/(?:^|\.?)([A-Z]|(?<=[a-z])\d(?=\d+[A-Z]))/g, function(x,y) {
       return "_" + y.toLowerCase()
     }).replace(/^_/, "");
   }

--- a/index.js
+++ b/index.js
@@ -116,7 +116,11 @@ module.exports.init = function() {
   };
 
   exports.camelCaseToUnderscore = function(s) {
-    return s.replace(/(?:^|\.?)([A-Z])/g, function(x,y) {
+    // Regex will also insert an underscore before a digit if that digit is preceded by a lowercase letter and followed
+    //  by one or more additional digits, so it will insert an underscore before the "8" and the "1" in
+    //  "windows80Ie10Tile" (yielding "windows_80_ie_10_tile", but NOT before the "6" in "ios6AndPriorIcons" (yielding
+    //  "ios6_and_prior_icons").
+    return s.replace(/(?:^|\.?)([A-Z]|(?<=[a-z])\d(?=\d+))/g, function(x,y) {
       return "_" + y.toLowerCase()
     }).replace(/^_/, "");
   }


### PR DESCRIPTION
"windows80Ie10Tile" and "windows10Ie11EdgeTiles" config options need to have underscores before both sets of numbers.

Converting from camelCase to underscore previously yielded "windows80_ie10_tile" and "windows10_ie11_edge_tiles", which was incorrect.

After the change the conversion now yields the correct values of "windows_80_ie_10_tile" and "windows_10_ie_11_edge_tiles".

Fixes RealFaviconGenerator/realfavicongenerator#267
Coincidentally Fixes RealFaviconGenerator/gulp-real-favicon#21
Coincidentally Fixes RealFaviconGenerator/grunt-real-favicon#43